### PR TITLE
徒歩圏内（到達圏）エリアの表示機能追加と高速化 (OpenRouteService API)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ folium
 geopy
 gunicorn
 psycopg2-binary
+requests


### PR DESCRIPTION
概要: 物件選びの重要な指標となる「駅からの徒歩圏内（15分）」を、地図上に可視化する機能を追加しました。 単純な円ではなく、道路網を考慮した到達圏（Isochrone）を表示するため、OpenRouteService APIを採用しました。

変更点:

ライブラリの追加: API通信用に requests を追加 (requirements.txt)。

到達圏の描画: OpenRouteService のAPIを使用し、新宿駅から徒歩15分（900秒）で到達可能なエリアを取得。folium.GeoJson を使用して地図上に緑色のポリゴンとして描画。

パフォーマンス改善 (キャッシュ):

外部APIへの通信は時間がかかるため、django.core.cache を導入。

一度取得したエリアデータは24時間キャッシュし、2回目以降の表示を高速化（0秒表示）した。

技術的メモ:

APIリクエストには requests ライブラリを使用。

APIキーは views.py 内に記述（※将来的に環境変数 .env への移行を検討）。

キャッシュキー: isochrone_shinjuku_15min