### PR TITLE
到達圏のグラデーション表示（5分・10分・15分）を実装

### DIFF
--- a/src/map_app/views.py
+++ b/src/map_app/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import HttpResponse
-from django.core.cache import cache # <--- ★記憶するための道具
+from django.core.cache import cache
 from .models import Property, Station
 from .forms import PropertyForm
 import folium
@@ -9,43 +9,48 @@ import time
 import requests
 import json
 
+# ---------------------------------------------------------
+# メイン画面：地図と到達圏の表示
+# ---------------------------------------------------------
 def map_view(request):
     # 初期位置（新宿あたり）
     m = folium.Map(location=[35.6909, 139.7005], zoom_start=13)
     
-    # 登録されている全駅を取得（チェックボックス表示用）
+    # 登録されている全駅を取得
     all_stations = Station.objects.all()
     
-    # ユーザーがチェックした駅のIDリストを取得（例: ['1', '3']）
-    # 何も選ばれていなければ空っぽ
+    # ユーザーがチェックした駅のIDリスト
     selected_ids = request.GET.getlist('stations')
 
-    # APIキー（ここだけ貼り直してください！）
+    # APIキー
     API_KEY = 'eyJvcmciOiI1YjNjZTM1OTc4NTExMTAwMDFjZjYyNDgiLCJpZCI6IjQwOTZjMDE0OTBjZDQxMmViNzEyYTRhMTAwZjVjYjNjIiwiaCI6Im11cm11cjY0In0='
 
-    # チェックされた駅の数だけループしてエリアを描画
     for station in all_stations:
-        # この駅がチェックされているか？（文字列として比較）
         if str(station.id) in selected_ids:
             
-            # --- ここからいつものAPIロジック ---
-            cache_key = f'isochrone_station_{station.id}_15min' # IDごとにキャッシュを分ける
+            # キャッシュキー（グラデーション用に名前を変更）
+            cache_key = f'isochrone_station_{station.id}_gradated' 
+            
             area_data = cache.get(cache_key)
 
             if not area_data:
                 print(f"🌍 {station.name} のデータをAPIに取りに行きます...")
+                
                 body = {
-                    "locations": [[station.longitude, station.latitude]], # geopyと逆順注意
-                    "range": [900], 
+                    "locations": [[station.longitude, station.latitude]],
+                    "range": [300, 600, 900], # 5分, 10分, 15分
                     "range_type": "time",
                     "attributes": ["area"],
                     "area_units": "m"
                 }
+
+                # APIキーを設定したヘッダー（ここが消えていたので復活！）
                 headers = {
                     "Accept": "application/json, application/geo+json",
                     "Authorization": API_KEY,
                     "Content-Type": "application/json; charset=utf-8"
                 }
+                
                 try:
                     call = requests.post(
                         'https://api.openrouteservice.org/v2/isochrones/foot-walking',
@@ -55,24 +60,29 @@ def map_view(request):
                     if call.status_code == 200:
                         area_data = call.json()
                         cache.set(cache_key, area_data, 86400)
+                    else:
+                        print(f"API Error: {call.text}")
                 except Exception as e:
                     print(f"Error: {e}")
 
-            # 描画（色は緑で統一し、重なると濃くなるようにOpacity調整）
             if area_data:
                 folium.GeoJson(
                     area_data,
-                    name=f'{station.name} 15分圏内',
-                    style_function=lambda x: {
+                    name=f'{station.name} 到達圏',
+                    style_function=lambda feature: {
                         'fillColor': '#00ff00', 
-                        'color': '#00ff00',
+                        'color': '#00ff00',    
                         'weight': 1,
-                        'fillOpacity': 0.15 # 重なると濃くなって綺麗です
+                        # 濃さの調整: 5分(300s)→0.4, 10分(600s)→0.2, 15分→0.1
+                        'fillOpacity': 0.4 if feature['properties']['value'] == 300 else \
+                                       0.2 if feature['properties']['value'] == 600 else \
+                                       0.1 
                     }
                 ).add_to(m)
 
     # ---------------------------------------------------------
-
+    # 物件ピンの表示
+    # ---------------------------------------------------------
     properties = Property.objects.all()
 
     for prop in properties:
@@ -122,7 +132,6 @@ def map_view(request):
             icon=folium.Icon(color=icon_color, icon=icon_icon, prefix='fa')
         ).add_to(m)
 
-    # テンプレートに渡すデータに「全駅」と「選択されたID」を追加
     context = {
         'map_data': m._repr_html_(),
         'all_stations': all_stations,
@@ -130,7 +139,9 @@ def map_view(request):
     }
     return render(request, 'map_app/index.html', context)
 
-# 登録・いいね機能はそのまま
+# ---------------------------------------------------------
+# 物件登録ページ
+# ---------------------------------------------------------
 def add_property(request):
     if request.method == 'POST':
         form = PropertyForm(request.POST)
@@ -151,6 +162,9 @@ def add_property(request):
         form = PropertyForm()
     return render(request, 'map_app/add_property.html', {'form': form})
 
+# ---------------------------------------------------------
+# いいね機能（Ajax用）
+# ---------------------------------------------------------
 def toggle_like(request, property_id):
     prop = get_object_or_404(Property, pk=property_id)
     if request.user.is_authenticated:


### PR DESCRIPTION
**概要:**
これまで一律の緑色で表示していた徒歩圏内エリアを、到達時間（5分・10分・15分）に応じて3段階の濃淡（グラデーション）で表示するように改良しました。
これにより、ユーザーは「駅チカ（5分以内）」と「徒歩圏内（15分以内）」を直感的に区別できるようになりました。

**変更点:**

* **APIリクエストの変更:** OpenRouteService APIへのリクエストパラメータ `range` を `[900]` から `[300, 600, 900]`（秒単位）に変更。
* **スタイル関数の拡張:** `folium` の `style_function` 内で三項演算子を使用し、到達時間（`value`）に応じた `fillOpacity`（塗りつぶしの濃さ）の動的切り替えを実装。
* 5分以内: 濃い緑 (Opacity 0.4)
* 10分以内: 普通の緑 (Opacity 0.2)
* 15分以内: 薄い緑 (Opacity 0.1)


* **キャッシュキーの更新:** データ構造の変更に伴い、キャッシュキーのサフィックスを `_gradated` に変更して整合性を確保。