### PR TITLE
feat: アンダーバーの追加と画面遷移の整備完了

### DIFF
--- a/src/map_app/urls.py
+++ b/src/map_app/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('setup/', views.group_setup, name='group_setup'),
+    path('leave/', views.leave_group, name='leave_group'),
     path('', views.map_view, name='index'),
     path('add/', views.add_property, name='add_property'),
     path('like/<int:property_id>/', views.toggle_like, name='toggle_like'),


### PR DESCRIPTION
やったこと
アンダーバーの実装: 全ページ共通で画面下にメニューを表示するようにした。

画面遷移の整理:

グループ未所属ならペア設定ページへ、所属済みなら地図ページへ飛ぶように修正。

物件登録後は地図に戻るように変更。

脱退機能: グループから抜ける処理を追加。
<img width="958" height="1027" alt="スクリーンショット 2026-01-24 011011" src="https://github.com/user-attachments/assets/9919ba79-e6b6-46c6-89dd-a0d62d6e956e" />


レイアウト修正: 地図の下に余白ができないようCSSを調整。